### PR TITLE
create MachineCanvas component

### DIFF
--- a/src/lib/tm.ts
+++ b/src/lib/tm.ts
@@ -279,6 +279,9 @@ export function tm_trace_to_image(
 	fitCanvas = true,
 	showHeadMove = false
 ) {
+	width = Math.max(1, Math.min(99_999, Math.floor(width) || 0));
+	height = Math.max(1, Math.min(99_999, Math.floor(height) || 0));
+
 	const imgData = ctx.createImageData(width, height);
 
 	const history = render_history(machine, initial_tape, height);

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -316,7 +316,7 @@
 							What is this?
 						</a>
 						<div>&middot;</div>
-						<div
+						<button
 							class="text-blue-400 hover:text-blue-300 cursor-pointer"
 							class:text-blue-300={showSimulationParams}
 							on:click={() => {
@@ -324,7 +324,7 @@
 							}}
 						>
 							Simulation Parameters
-						</div>
+						</button>
 					</div>
 					<div class="mt-1 flex flex-col">
 						{#if showSimulationParams}
@@ -338,6 +338,12 @@
 											bind:value={nbIter}
 											on:change={() => {
 												window.history.replaceState({}, '', getSimulationLink());
+											}}
+											min="1"
+											max="99999"
+											on:blur={(e) => {
+												nbIter = Math.max(1, Math.min(99999, Math.round(nbIter || 0)));
+												e.currentTarget.value = nbIter.toString();
 											}}
 										/></label
 									>

--- a/src/routes/(app)/MachineCanvas.svelte
+++ b/src/routes/(app)/MachineCanvas.svelte
@@ -68,20 +68,4 @@
 
 <div class="relative mr-5">
 	<canvas class="bg-slate-800 image-render-pixel" bind:this={canvas} width="400" height="500" />
-
-	{#if canvas && machine}
-		<button
-			class="absolute right-2 top-2 text-blue-400 hover:text-blue-300 cursor-pointer"
-			on:click={() => {
-				var image = new Image();
-				image.src = canvas.toDataURL();
-				let w = window.open('');
-
-				const title = `machine-${machineName || 'simulation'}`;
-				w.document.write(`<head><title>${title}</title></head><body>${image.outerHTML}</body>`);
-			}}
-		>
-			Export image
-		</button>
-	{/if}
 </div>

--- a/src/routes/(app)/MachineCanvas.svelte
+++ b/src/routes/(app)/MachineCanvas.svelte
@@ -1,0 +1,87 @@
+<script>
+	import { tm_trace_to_image, tm_explore } from '$lib/tm';
+
+	export let exploreMode;
+	export let machine;
+	export let initial_tape;
+	export let tapeWidth;
+	export let nbIter;
+	export let origin_x;
+	export let showHeadMove;
+
+	export let machineName;
+
+	let canvas;
+
+	const drawRect = (context) => {
+		context.fillStyle = 'black';
+		context.fillRect(0, 0, canvas.width, canvas.height);
+		context.fill();
+	};
+
+	let drawCleanup;
+	function draw() {
+		if (drawCleanup) drawCleanup();
+
+		// Update the width of the canvas inside of `draw`, because otherwise
+		// it gets updated _afterward_ by the Svelte update loop, which will
+		// blank out the canvas entirely.
+		canvas.width = exploreMode ? 800 : 400;
+
+		if (!machine) {
+			return;
+		}
+
+		const context = canvas.getContext('2d');
+		drawRect(context);
+		if (exploreMode) {
+			drawCleanup = tm_explore(context, machine, initial_tape, nbIter);
+		} else {
+			tm_trace_to_image(
+				context,
+				machine,
+				initial_tape,
+				tapeWidth,
+				nbIter,
+				origin_x,
+				true,
+				showHeadMove
+			);
+		}
+	}
+
+	$: {
+		// Dependencies:
+		exploreMode;
+		machine;
+		initial_tape;
+		tapeWidth;
+		nbIter;
+		origin_x;
+		showHeadMove;
+
+		if (canvas) {
+			draw();
+		}
+	}
+</script>
+
+<div class="relative mr-5">
+	<canvas class="bg-slate-800 image-render-pixel" bind:this={canvas} width="400" height="500" />
+
+	{#if canvas && machine}
+		<button
+			class="absolute right-2 top-2 text-blue-400 hover:text-blue-300 cursor-pointer"
+			on:click={() => {
+				var image = new Image();
+				image.src = canvas.toDataURL();
+				let w = window.open('');
+
+				const title = `machine-${machineName || 'simulation'}`;
+				w.document.write(`<head><title>${title}</title></head><body>${image.outerHTML}</body>`);
+			}}
+		>
+			Export image
+		</button>
+	{/if}
+</div>

--- a/src/routes/(thumbnail)/thumbnail/[gid]/+page.svelte
+++ b/src/routes/(thumbnail)/thumbnail/[gid]/+page.svelte
@@ -13,7 +13,7 @@
 	let machineCode = null;
 
 	const nbIterDefault = 10000;
-	const tapeWidthDefault = 300;
+	const tapeWidthDefault = 400;
 	const origin_xDefault = 0.5;
 	let nbIter = nbIterDefault;
 	let tapeWidth = tapeWidthDefault;


### PR DESCRIPTION
The new `<MachineCanvas />` component pulls out the drawing-related state for rendering the simulation, including the "export image" button.

<img width="415" alt="Screenshot 2023-09-09 at 8 43 23 PM" src="https://github.com/bbchallenge/bbchallenge/assets/6179181/601f7621-d9be-4ca6-95c5-ae580b089f46">

Now, `draw()` is called when the machine or its parameters change, without needing to call it explicitly whenever you change one of those, so it's a lot less error-prone (there appears to be some state which is not consistently updated through the page because of issues like this).

I changed the default simulation with from 300 to 400, so that it exactly matches the width of the actual canvas - this should make it less blurry by default.