### PR TITLE
Don't crash the simulation when drawing halted tape

### DIFF
--- a/src/lib/tm.ts
+++ b/src/lib/tm.ts
@@ -202,7 +202,7 @@ export function tm_explore(
 				}
 			}
 
-			if (curr_state < colorList.length) {
+			if (curr_state !== null && curr_state < colorList.length) {
 				ctx.fillStyle = `rgb(${colorList[curr_state].join(', ')})`;
 				ctx.fillRect(curr_pos, row, 1, 1);
 			}


### PR DESCRIPTION
Closes #26, preventing a crash caused by looking up the color for the `null` state.

This error _could have been caught_ by TypeScript, but the current tsconfig is not strict enough. I'd like to enable strict typechecking in a future PR, but there are a lot of existing type errors that need to be addressed first before this is possible.