### PR TITLE
Remove closed issues

### DIFF
--- a/src/routes/(app)/contribute/+page.md
+++ b/src/routes/(app)/contribute/+page.md
@@ -100,12 +100,6 @@ If you reproduce results of the Busy Beaver Challenge please share about your re
 
 This website is also written collaboratively, [its code](https://github.com/bbchallenge/bbchallenge) can be improved in many ways!
 
-Here are some examples of missing features:
-
-- A better, more customizable, visualisation tool for <a href="/story#space-time-diagrams">space-time diagrams</a>. See [this issue](https://github.com/bbchallenge/bbchallenge/issues/2).
-- Make Turing machines editable on the fly on the main page. See [this issue](https://github.com/bbchallenge/bbchallenge/issues/4).
-- If a machine of the database is decided, such as <a href="https://bbchallenge.org/59090563" rel="external">#59,090,563</a>, give the link to its decider. See [this issue](https://github.com/bbchallenge/bbchallenge-api/issues/2).
-
 Pages like <a href="/story" rel="external">/story</a>, <a href="/method" rel="external">/method</a>, <a href="/contribute" rel="external">/contribute</a> are also collaborative and you can submit changes on [github](https://github.com/bbchallenge/bbchallenge).
 
 <a id="share-the-story"></a>


### PR DESCRIPTION
The [contribution page](https://bbchallenge.org/contribute) lists https://github.com/bbchallenge/bbchallenge/issues/2, https://github.com/bbchallenge/bbchallenge/issues/4, and https://github.com/bbchallenge/bbchallenge-api/issues/2 as potential ways someone can contribute to the project. But all of these issues are marked as completed. This PR removes them from the contribution page.