### PR TITLE
Avoid making the logo huge in Discord embeds

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -26,7 +26,6 @@
 	<meta property="og:image" content="https://bbchallenge.org/branding/bbchallenge_logo.png">
 
 	<!-- Twitter Meta Tags -->
-	<meta name="twitter:card" content="summary_large_image">
 	<meta property="twitter:domain" content="bbchallenge.org">
 	<meta property="twitter:url" content="https://bbchallenge.org">
 	<meta name="twitter:title" content="The Busy Beaver Challenge">


### PR DESCRIPTION
Apparently this was being caused by the `twitter:card` tag. I haven't checked how it actually affects Twitter cards, as I don't have access to the necessary tools at the moment.