### PR TITLE
Store sim parameters in URL search params

### DIFF
--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -92,7 +92,7 @@
 	}
 
 	function getSimulationLink(forCopy = false) {
-		let prefix = 'https://bbchalenge.org/';
+		let prefix = 'https://bbchallenge.org/';
 		if (!forCopy) {
 			prefix = '/';
 		}
@@ -103,23 +103,25 @@
 			secondPrefix = machineCode;
 		}
 
-		let last_add = '';
-		if (machineStatus !== null && machineID === null) {
-			last_add = `&status=${machineStatus}`;
-		}
-
-		let simulationParametersLink = '';
+		let simulationParams = new URLSearchParams();
 		if (nbIter !== nbIterDefault) {
-			simulationParametersLink += `&s=${nbIter}`;
+			simulationParams.set('s', nbIter);
 		}
 		if (tapeWidth !== tapeWidthDefault) {
-			simulationParametersLink += `&w=${tapeWidth}`;
+			simulationParams.set('w', tapeWidth);
 		}
 		if (origin_x !== origin_xDefault) {
-			simulationParametersLink += `&ox=${origin_x}`;
+			simulationParams.set('ox', origin_x);
+		}
+		if (machineStatus !== null && machineID === null) {
+			simulationParams.set('status', machineStatus);
+		}
+		let suffix = simulationParams.toString();
+		if (suffix !== '') {
+			suffix = '?' + suffix;
 		}
 
-		return prefix + secondPrefix + simulationParametersLink + last_add;
+		return prefix + secondPrefix + suffix;
 	}
 
 	let showRandomOptions = false;
@@ -432,7 +434,7 @@
 											type="number"
 											bind:value={nbIter}
 											on:change={() => {
-												window.history.pushState({}, '', getSimulationLink());
+												window.history.replaceState({}, '', getSimulationLink());
 											}}
 											min="1"
 											max="99999"
@@ -449,7 +451,7 @@
 											type="number"
 											bind:value={tapeWidth}
 											on:change={() => {
-												window.history.pushState({}, '', getSimulationLink());
+												window.history.replaceState({}, '', getSimulationLink());
 											}}
 										/></label
 									>
@@ -460,7 +462,7 @@
 											type="number"
 											bind:value={origin_x}
 											on:change={() => {
-												window.history.pushState({}, '', getSimulationLink());
+												window.history.replaceState({}, '', getSimulationLink());
 											}}
 											min="0"
 											max="1"
@@ -690,8 +692,8 @@
 								on:machine_id={async (ev) => {
 									let machine_id = ev.detail.machine_id;
 
-									await loadMachineFromID(machine_id);
 									defaultSimulationParameters();
+									await loadMachineFromID(machine_id);
 								}}
 							/>
 						{/if}
@@ -704,15 +706,15 @@
 								on:machine_id={async (ev) => {
 									let machine_id = ev.detail.machine_id;
 
-									await loadMachineFromID(machine_id);
 									defaultSimulationParameters();
+									await loadMachineFromID(machine_id);
 								}}
 								on:machine_code={async (ev) => {
 									let machine_code = ev.detail.machine_code;
 									let machine_status = ev.detail.machine_status;
 
-									await loadMachineFromMachineCode(machine_code, machine_status);
 									defaultSimulationParameters();
+									await loadMachineFromMachineCode(machine_code, machine_status);
 								}}
 							/>
 						{/if}
@@ -721,15 +723,15 @@
 								on:machine_id={async (ev) => {
 									let machine_id = ev.detail.machine_id;
 
-									await loadMachineFromID(machine_id);
 									defaultSimulationParameters();
+									await loadMachineFromID(machine_id);
 								}}
 								on:machine_code={async (ev) => {
 									let machine_code = ev.detail.machine_code;
 									let machine_status = ev.detail.machine_status;
 
-									await loadMachineFromMachineCode(machine_code, machine_status);
 									defaultSimulationParameters();
+									await loadMachineFromMachineCode(machine_code, machine_status);
 								}}
 							/>
 						{/if}
@@ -738,15 +740,15 @@
 								on:machine_id={async (ev) => {
 									let machine_id = ev.detail.machine_id;
 
-									await loadMachineFromID(machine_id);
 									defaultSimulationParameters();
+									await loadMachineFromID(machine_id);
 								}}
 								on:machine_code={async (ev) => {
 									let machine_code = ev.detail.machine_code;
 									let machine_status = ev.detail.machine_status;
 
-									await loadMachineFromMachineCode(machine_code, machine_status);
 									defaultSimulationParameters();
+									await loadMachineFromMachineCode(machine_code, machine_status);
 								}}
 							/>
 						{/if}
@@ -755,15 +757,15 @@
 								on:machine_id={async (ev) => {
 									let machine_id = ev.detail.machine_id;
 
-									await loadMachineFromID(machine_id);
 									defaultSimulationParameters();
+									await loadMachineFromID(machine_id);
 								}}
 								on:machine_code={async (ev) => {
 									let machine_code = ev.detail.machine_code;
 									let machine_status = ev.detail.machine_status;
 
-									await loadMachineFromMachineCode(machine_code, machine_status);
 									defaultSimulationParameters();
+									await loadMachineFromMachineCode(machine_code, machine_status);
 								}}
 							/>
 						{/if}

--- a/src/routes/(app)/[gid=machine]/+page.server.ts
+++ b/src/routes/(app)/[gid=machine]/+page.server.ts
@@ -1,0 +1,16 @@
+import { redirect } from '@sveltejs/kit';
+
+export function load({ url }) {
+	// Redirect from old URLs with ampersand-delimited parameters
+	const pathname = url.pathname;
+	const ampIndex = pathname.indexOf('&');
+	if (ampIndex !== -1) {
+		const newPathname = pathname.slice(0, ampIndex);
+		let search = pathname.slice(ampIndex + 1);
+		if (url.search !== '')
+			search += '&' + url.search.slice(1);
+		let newUrl = new URL(newPathname, url);
+		newUrl.search = search;
+		throw redirect(301, newUrl);
+	}
+}

--- a/src/routes/(app)/[gid=machine]/+page.svelte
+++ b/src/routes/(app)/[gid=machine]/+page.svelte
@@ -1,17 +1,16 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import MainPage from '../+page.svelte';
 	import { page } from '$app/stores';
 	import { TMDecisionStatus } from '$lib/tm';
 
 	// Machine ID or machine b64
-	let generalisedIDAndParams = $page.params.gid;
-
-	let generalisedID = generalisedIDAndParams.split('&')[0];
+	let generalisedID = $page.params.gid;
 
 	let machineID = null;
 	let machineCode = null;
 
-	if ((generalisedID.length > 0 && generalisedID[1] == 'R') || generalisedID[1] == 'L') {
+	if (generalisedID.length > 0 && (generalisedID[1] == 'R' || generalisedID[1] == 'L')) {
 		machineCode = generalisedID;
 		machineID = null;
 	} else {
@@ -19,14 +18,23 @@
 		machineCode = null;
 	}
 
-	let urlParams = new URLSearchParams(generalisedIDAndParams);
-	let sUrlParam = urlParams.get('s');
-	let nbIter = sUrlParam ? Number(sUrlParam) : undefined;
-	let wUrlParam = urlParams.get('w');
-	let tapeWidth = wUrlParam ? Number(wUrlParam) : undefined;
-	let oxUrlParam = urlParams.get('ox');
-	let origin_x = oxUrlParam ? Number(oxUrlParam) : undefined;
-	let machineStatus = machineStatusFromUrlParam(urlParams);
+	let nbIter;
+	let tapeWidth;
+	let origin_x;
+	let machineStatus;
+
+	onMount(() => {
+		let urlParams = $page.url.searchParams;
+		nbIter = numberFromUrlParam(urlParams, 's');
+		tapeWidth = numberFromUrlParam(urlParams, 'w');
+		origin_x = numberFromUrlParam(urlParams, 'ox');
+		machineStatus = machineStatusFromUrlParam(urlParams);
+	});
+
+	function numberFromUrlParam(urlParams: URLSearchParams, name: string): number | undefined {
+		const value = urlParams.get(name);
+		return value !== null ? Number(value) : undefined;
+	}
 
 	function machineStatusFromUrlParam(urlParams: URLSearchParams): TMDecisionStatus {
 		const statusUrlParam = urlParams.get('status');

--- a/src/routes/(app)/method/+page.md
+++ b/src/routes/(app)/method/+page.md
@@ -154,7 +154,7 @@ We conjecture:
 BB_SPACE(5) =  12,289
 </div>
 
-Which is the number of memory cells visited by <a  href="https://bbchallenge.org/{BB5_champion}&w=250&ox=0.8&status=halt" rel="external">the 5-state busy beaver time champion</a>.
+Which is the number of memory cells visited by <a href="https://bbchallenge.org/{BB5_champion}?w=250&ox=0.8&status=halt" rel="external">the 5-state busy beaver time champion</a>.
 
 It turns that BB_SPACE(5) is a much more practical cut-off to use in the enumeration algorithm than BB(5) as many more machines will visit more than 12,289 memory cells before they exceed 47,176,870 time steps.
 

--- a/src/routes/(app)/story/+page.md
+++ b/src/routes/(app)/story/+page.md
@@ -58,7 +58,7 @@ BB(5) = 47,176,870
 
 This conjecture says that if a 5-state 2-symbol [Turing machine](#turing-machines) runs for more than 47,176,870 steps without halting then it will never halt (starting from all-0 memory tape).
 
-The conjecture, explicitly formulated in [[Aaronson, 2020]](https://www.scottaaronson.com/papers/bb.pdf), is based on the pioneering work of [[Marxen and Buntrock, 1990]](http://turbotm.de/~heiner/BB/mabu90.html) who discovered the current <a  href="https://bbchallenge.org/{BB5_champion}&w=250&ox=0.8&status=halt" rel="external">5-state busy beaver champion</a>, a machine with 5 states that halts after 47,176,870 steps:
+The conjecture, explicitly formulated in [[Aaronson, 2020]](https://www.scottaaronson.com/papers/bb.pdf), is based on the pioneering work of [[Marxen and Buntrock, 1990]](http://turbotm.de/~heiner/BB/mabu90.html) who discovered the current <a href="https://bbchallenge.org/{BB5_champion}?w=250&ox=0.8&status=halt" rel="external">5-state busy beaver champion</a>, a machine with 5 states that halts after 47,176,870 steps:
 
 <div class="flex flex-col items-center">
 <div class="w-1/3 -mt-5 font-mono">
@@ -88,7 +88,7 @@ Turing machines can be thought as a primitive computer architecture providing (i
 
 The Turing machines we work with have one bi-infinite memory tape where each cell is either containing a 0 or a 1.
 
-The programmer specifies the code of the machine in a table with 2 columns and <span class="math math-inline">q</span> rows. Rows are called **states**. Here is the code of the current <a  href="https://bbchallenge.org/{BB5_champion}&w=250&ox=0.8&status=halt">5-state busy beaver champion</a>:
+The programmer specifies the code of the machine in a table with 2 columns and <span class="math math-inline">q</span> rows. Rows are called **states**. Here is the code of the current <a href="https://bbchallenge.org/{BB5_champion}?w=250&ox=0.8&status=halt">5-state busy beaver champion</a>:
 
 <div class="flex flex-col items-center -mb-2">
 <div class="w-1/3 -mt-5 font-mono">
@@ -132,7 +132,7 @@ A more detailed simulator is available at <a href="https://turingmachine.io" tar
 
 Space-time diagrams provide a condensed way to visualise the behavior of [Turing machines](#turing-machines). The space-time diagram of a machine is a 2D image where the i<sup>th</sup> row represents the memory tape of the machine at the i<sup>th</sup> iteration. Black pixels are used for memory cells containing 0 and white for 1.
 
-Here is the space-time diagram of the first 10,000 iterations of the <a  href="https://bbchallenge.org/{BB5_champion}&w=250&ox=0.8&status=halt" rel="external">5-state busy beaver champion</a>:
+Here is the space-time diagram of the first 10,000 iterations of the <a href="https://bbchallenge.org/{BB5_champion}?w=250&ox=0.8&status=halt" rel="external">5-state busy beaver champion</a>:
 
 <div class="flex justify-center -mt-16 -mb-8">
 
@@ -262,7 +262,7 @@ Hence, the frontier between tractable and intractable values of BB seems to be s
 
 The above motivates the Busy Beaver Challenge: **let's try to collaboratively find BB(5)**, the smallest currently unknown BB value.
 
-Prior work exhibited the current <a  href="https://bbchallenge.org/{BB5_champion}&w=250&ox=0.8&status=halt" rel="external">5-state busy beaver champion</a> halting after 47,176,870 steps [[Marxen and Buntrock, 1990]](http://turbotm.de/~heiner/BB/mabu90.html) which has not been beaten in the past 30 years.
+Prior work exhibited the current <a href="https://bbchallenge.org/{BB5_champion}?w=250&ox=0.8&status=halt" rel="external">5-state busy beaver champion</a> halting after 47,176,870 steps [[Marxen and Buntrock, 1990]](http://turbotm.de/~heiner/BB/mabu90.html) which has not been beaten in the past 30 years.
 
 This led to [[Aaronson, 2020]](https://www.scottaaronson.com/papers/bb.pdf) conjecturing that BB(5) = 47,176,870.
 


### PR DESCRIPTION
This commit does a few different things:

- Replace `/pathname&foo=1&bar=2` URLs with `/pathname?foo=1&bar=2` URLs, using a proper query string. Adjust the initialization code in `/(app)/[gid=machine]/+page.svelte`, the `getSimulationLink()` function in `/(app)/+page.svelte`, and the links in prose accordingly.
- Add a `load()` function to `/(app)/[gid=machine]/+page.server.ts` to automatically redirect from the old URLs to the new URLs.
- Use `replaceState()` instead of `pushState()` for sim parameter changes to avoid polluting the back-button history unnecessarily. (It still doesn't work properly, but a complete fix would be much larger in scope.)
- In the example machine links, reset the `defaultSimulationParameters()` *before* updating the URL, so that the parameters in the URL match the ones displayed on the page.