### PR TITLE
Improve support for initial tape

### DIFF
--- a/src/lib/tm.ts
+++ b/src/lib/tm.ts
@@ -143,15 +143,34 @@ function naturalToInt(n: number) {
 	return n % 2 == 0 ? n / 2 : -(n + 1) / 2;
 }
 
+function parse_initial_tape(machine: TM, initial_tape: string) {
+	const raw_tape = [];
+	let state = 0;
+	let pos = 0;
+
+	for (let i = 0; i < initial_tape.length; i++) {
+		const c = initial_tape.charCodeAt(i);
+		if (48 <= c && c < 48 + machine.symbols) {
+			raw_tape.push(c - 48);
+		}
+		else if ((65 <= c && c < 65 + machine.states) || (97 <= c && c < 97 + machine.states)) {
+			state = (c - 1) % 32;
+			pos = raw_tape.length;
+		}
+	}
+
+	const tape = [];
+	for (let i = 0; i < raw_tape.length; i++) {
+		tape[intToNatural(i - pos)] = raw_tape[i];
+	}
+
+	return {tape, state};
+}
+
 export function render_history(machine: TM, initial_tape = '0', height = 1000) {
 	const history = [];
 
-	let tape = [];
-	for (let i = 0; i < initial_tape.length; i++) {
-		tape[intToNatural(i)] = initial_tape[i] === '0' ? 0 : 1;
-	}
-
-	let curr_state = 0;
+	let {tape, state: curr_state} = parse_initial_tape(machine, initial_tape);
 	let curr_pos = 0;
 	history.push({ tape, curr_state, curr_pos });
 


### PR DESCRIPTION
Closes #28. Closes #38.

* Ignore characters that are not symbols or states.
* Add support for all symbols. (Previously, only `0` and `1` were supported)
* Add support for a different initial state. (Previously, only `A` was supported)

The parser follows Definition 6.2 "Word-representations of a configuration". e.g. for `1100C1100`, the left side is `...1100`, the head is `C1`, and the right side is `100...`. If there is no state, then default to A.